### PR TITLE
Removed dependency for WP default constant, by using new own constant…

### DIFF
--- a/network-subdomain-updater.php
+++ b/network-subdomain-updater.php
@@ -19,13 +19,13 @@ class SubdomainUpdate {
 
     define( __NAMESPACE__ . '\VERSION', '1.0.4' );
 
-    // If DOMAIN_CURRENT_SITE isn't defined, do nothing.
-    if( !defined( 'DOMAIN_CURRENT_SITE' ) || !trim( DOMAIN_CURRENT_SITE ) ) return;
+    // If NSDU_URL isn't defined, do nothing.
+    if( !defined( 'NSDU_URL' ) || !trim( NSDU_URL ) ) return;
 
     // If network domain hasn't changed, do nothing.
     global $wpdb;
     $current_domain = $this->trim_www( current( $wpdb->get_col( $wpdb->prepare( "SELECT domain FROM $wpdb->site WHERE id = %d", SITE_ID_CURRENT_SITE ) ) ) );
-    $this->primary_site_domain = strtolower( trim( DOMAIN_CURRENT_SITE ) ); // Example: www.example.com
+    $this->primary_site_domain = strtolower( trim( NSDU_URL ) ); // Example: www.example.com
     $local_domain = $this->trim_www( $this->primary_site_domain ); // Example: example.com
 
     if( !$current_domain || $current_domain == $local_domain ) return;


### PR DESCRIPTION
This PR removes the dependency for the WP default constant `DOMAIN_CURRENT_SITE` and introduce an new one called `NSDU_URL`, that everybody can use safely.

The most easy way would be to `define( 'NSDU_URL', DOMAIN_CURRENT_SITE );` in the wp-config.php

This has 2 benefits:

1. The default constant could be used *different* from default, what could cause Problems, while using it for the DB updates. In example if it was set dynamically like this:

```
if ( isset( $_SERVER['X_FORWARDED_HOST'] ) && !empty( $_SERVER['X_FORWARDED_HOST'] ) ) {
	$hostname = $_SERVER['X_FORWARDED_HOST'];
} else {
	$hostname = $_SERVER['HTTP_HOST'];
}
define( 'DOMAIN_CURRENT_SITE', rtrim($hostname, '/') );
```

2. By not defining the new constant, e.g. on production sites, the Plugin would stop its work earlier and so be faster at all, while not doing its first DB hit.

---

btw

**Thank you very much, for your nice work and also for publishing it.**

Carsten